### PR TITLE
use another case for `satisifies`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ const Button3: React.FC<ButtonProps> = ({ children }) => {
 // 安全だが関数本体をカッコで囲む必要がある。また TypeScript 4.9 時点では定義元ジャンプもワンクッションあり。
 const Button4 = (({ children }) => {
   return <button>{children}</button>;
-}) satisfies React.FC<ButtonProps> ;
+}) satisfies React.FC<ButtonProps>;
 
 export default function App() {
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,12 @@ const Button3: React.FC<ButtonProps> = ({ children }) => {
   return <button>{children}</button>;
 };
 
+// アロー関数 + satisfiesで制約を加えつつ正確な型を表現する。
+// 安全だが関数本体をカッコで囲む必要がある。また TypeScript 4.9 時点では定義元ジャンプもワンクッションあり。
+const Button4 = (({ children }) => {
+  return <button>{children}</button>;
+}) satisfies React.FC<ButtonProps> ;
+
 export default function App() {
   return (
     <div>
@@ -31,6 +37,7 @@ export default function App() {
       <Button1>Click me!</Button1>
       <Button2>Click me!</Button2>
       <Button3>Click me!</Button3>
+      <Button4>Click me!</Button4>
     </div>
   );
 }


### PR DESCRIPTION
TS 4.9の新機能 `satisfies` を使うと意味的には理想的です。カッコが必要なので今はまだ実用的ではないかもしれませんが。演算子優先順位が見直されて `(...) => { ... } satisifes T` とできるようになるといいんですけど。
